### PR TITLE
fix: Correct value in saviour's sacrifice major ID

### DIFF
--- a/major_ids.json
+++ b/major_ids.json
@@ -32,7 +32,7 @@
   {
     "id": "HERO",
     "name": "Saviour's Sacrifice",
-    "lore": "While under 50% maximum health, nearby allies gain 30% bonus damage and defence"
+    "lore": "While under 50% maximum health, nearby allies gain 20% bonus damage and defence"
   },
   {
     "id": "ARCANES",

--- a/urls.json
+++ b/urls.json
@@ -129,7 +129,7 @@
   },
   {
     "id": "dataStaticMajorIds",
-    "md5": "a0013f56ac6434c7b37abdccf238d159",
+    "md5": "370a3208e21274ba247c64db3d597162",
     "url": "https://raw.githubusercontent.com/Wynntils/WynntilsWebsite-API/master/major_ids.json"
   },
   {


### PR DESCRIPTION
![image](https://github.com/Wynntils/WynntilsWebsite-API/assets/3767283/c34b9a0b-6e0d-41a8-bb76-437d79a7609e)
